### PR TITLE
RTCP unknown packet

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,0 @@
-# TODO
-
-- Remove `setPadding()`. Nobody should need it but only `padTo4Bytes()`.
-
-- RtcpPacket parent constructor should throw if byte length is not multiple of 4 bytes

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+- Remove `setPadding()`. Nobody should need it but only `padTo4Bytes()`.
+
+- RtcpPacket parent constructor should throw if byte length is not multiple of 4 bytes

--- a/src/Packet.ts
+++ b/src/Packet.ts
@@ -115,27 +115,6 @@ export abstract class Packet extends EnhancedEventEmitter<PacketEvents>
 	}
 
 	/**
-	 * Set the padding (in bytes) after the packet.
-	 *
-	 * @remarks
-	 * - Serialization maybe needed after calling this method.
-	 */
-	setPadding(padding: number): void
-	{
-		if (padding === this.padding)
-		{
-			return;
-		}
-
-		this.padding = padding;
-
-		// Update padding bit.
-		this.setPaddingBit(this.padding ? 1 : 0);
-
-		this.setSerializationNeeded(true);
-	}
-
-	/**
 	 * Pad the packet total length to 4 bytes. To achieve it, this method may add
 	 * or remove bytes of padding.
 	 *
@@ -219,6 +198,21 @@ export abstract class Packet extends EnhancedEventEmitter<PacketEvents>
 			0,
 			setBit(this.packetView.getUint8(0), 5, bit)
 		);
+	}
+
+	protected setPadding(padding: number): void
+	{
+		if (padding === this.padding)
+		{
+			return;
+		}
+
+		this.padding = padding;
+
+		// Update padding bit.
+		this.setPaddingBit(this.padding ? 1 : 0);
+
+		this.setSerializationNeeded(true);
 	}
 
 	protected setSerializationNeeded(flag: boolean): void

--- a/src/RtpPacket.ts
+++ b/src/RtpPacket.ts
@@ -878,7 +878,7 @@ export class RtpPacket extends Packet
 	/**
 	 * Get the packet payload.
 	 */
-	getPayloadView(): DataView
+	getPayload(): DataView
 	{
 		return this.#payloadView;
 	}
@@ -889,7 +889,7 @@ export class RtpPacket extends Packet
 	 * @remarks
 	 * - Serialization is needed after calling this method.
 	 */
-	setPayloadView(view: DataView): void
+	setPayload(view: DataView): void
 	{
 		this.#payloadView = view;
 
@@ -978,7 +978,7 @@ export class RtpPacket extends Packet
 		this.setSequenceNumber(sequenceNumber);
 
 		// Reduce the payload.
-		this.setPayloadView(
+		this.setPayload(
 			new DataView(this.#payloadView.buffer, this.#payloadView.byteOffset + 2)
 		);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ export {
 	ByePacketDump
 } from './rtcp/ByePacket';
 
+export {
+	UnknownPacket,
+	UnknownPacketDump
+} from './rtcp/UnknownPacket';
+
 import {
 	nodeBufferToDataView,
 	nodeBufferToArrayBuffer,

--- a/src/rtcp/ByePacket.ts
+++ b/src/rtcp/ByePacket.ts
@@ -222,6 +222,14 @@ export class ByePacket extends RtcpPacket
 			);
 		}
 
+		// Assert that RTCP header length field is correct.
+		if (getRtcpLength(packetView) !== packetView.byteLength)
+		{
+			throw new RangeError(
+				`length in the RTCP header (${getRtcpLength(packetView)} bytes) does not match the available buffer size (${packetView.byteLength} bytes)`
+			);
+		}
+
 		// Update DataView.
 		this.packetView = packetView;
 
@@ -255,6 +263,22 @@ export class ByePacket extends RtcpPacket
 	setSsrcs(ssrcs: number[]): void
 	{
 		this.#ssrcs = Array.from(ssrcs);
+
+		// Update RTCP count.
+		this.setCount(this.#ssrcs.length);
+
+		this.setSerializationNeeded(true);
+	}
+
+	/**
+	 * Add SSRC value.
+	 *
+	 * @remarks
+	 * - Serialization is needed after calling this method.
+	 */
+	addSsrc(ssrc: number): void
+	{
+		this.#ssrcs.push(ssrc);
 
 		// Update RTCP count.
 		this.setCount(this.#ssrcs.length);

--- a/src/rtcp/CompoundPacket.ts
+++ b/src/rtcp/CompoundPacket.ts
@@ -161,17 +161,6 @@ export class CompoundPacket extends Packet
 	 *
 	 * @hidden
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	setPadding(padding: number): void
-	{
-		throw new Error('method not implemented in RTCP CompoundPacket');
-	}
-
-	/**
-	 * Not implemented in RTCP Compound packet.
-	 *
-	 * @hidden
-	 */
 	padTo4Bytes(): void
 	{
 		throw new Error('method not implemented in RTCP CompoundPacket');

--- a/src/rtcp/CompoundPacket.ts
+++ b/src/rtcp/CompoundPacket.ts
@@ -1,4 +1,3 @@
-import { Logger } from '../Logger';
 import { Packet, PacketDump } from '../Packet';
 import {
 	isRtcp,
@@ -11,8 +10,7 @@ import {
 import { ReceiverReportPacket } from './ReceiverReportPacket';
 import { SenderReportPacket } from './SenderReportPacket';
 import { ByePacket } from './ByePacket';
-
-const logger = new Logger('RTCP::CompoundPacket');
+import { UnknownPacket } from './UnknownPacket';
 
 /**
  * RTCP Compound packet info dump.
@@ -103,9 +101,7 @@ export class CompoundPacket extends Packet
 
 				default:
 				{
-					// TODO: Here we may have an UnknownPacket class instead of discarding it.
-
-					logger.warn(`constructor() | discarding RTCP packet with unsupported packet type ${packetType}`);
+					packet = new UnknownPacket(packetView);
 				}
 			}
 

--- a/src/rtcp/ReceiverReportPacket.ts
+++ b/src/rtcp/ReceiverReportPacket.ts
@@ -230,6 +230,14 @@ export class ReceiverReportPacket extends RtcpPacket
 			);
 		}
 
+		// Assert that RTCP header length field is correct.
+		if (getRtcpLength(packetView) !== packetView.byteLength)
+		{
+			throw new RangeError(
+				`length in the RTCP header (${getRtcpLength(packetView)} bytes) does not match the available buffer size (${packetView.byteLength} bytes)`
+			);
+		}
+
 		// Update DataView.
 		this.packetView = packetView;
 
@@ -279,6 +287,22 @@ export class ReceiverReportPacket extends RtcpPacket
 	setReports(reports: ReceiverReport[]): void
 	{
 		this.#reports = Array.from(reports);
+
+		// Update RTCP count.
+		this.setCount(this.#reports.length);
+
+		this.setSerializationNeeded(true);
+	}
+
+	/**
+	 * Add Receiver Report.
+	 *
+	 * @remarks
+	 * - Serialization is needed after calling this method.
+	 */
+	addReport(report: ReceiverReport): void
+	{
+		this.#reports.push(report);
 
 		// Update RTCP count.
 		this.setCount(this.#reports.length);

--- a/src/rtcp/RtcpPacket.ts
+++ b/src/rtcp/RtcpPacket.ts
@@ -131,7 +131,7 @@ export abstract class RtcpPacket extends Packet
 	}
 
 	/**
-	 * Get the RTCP packet type.
+	 * Get the RTCP header packet type.
 	 */
 	getPacketType(): RtcpPacketType
 	{
@@ -209,7 +209,7 @@ export abstract class RtcpPacket extends Packet
 	}
 
 	/**
-	 * Set the RTCP packet type.
+	 * Set the RTCP header packet type.
 	 */
 	private setPacketType(packetType: RtcpPacketType): void
 	{

--- a/src/rtcp/RtcpPacket.ts
+++ b/src/rtcp/RtcpPacket.ts
@@ -90,6 +90,14 @@ export function getRtcpLength(view: DataView): number
  */
 function setRtcpLength(view: DataView, byteLength: number): void
 {
+	// RTCP packet byte length must be multiple of 4.
+	if (byteLength % 4 !== 0)
+	{
+		throw new RangeError(
+			`RTCP packet byte length must be multiple of 4 but given byte length is ${byteLength} bytes`
+		);
+	}
+
 	const length = (byteLength / 4) - 1;
 
 	view.setUint16(2, length);
@@ -110,6 +118,14 @@ export abstract class RtcpPacket extends Packet
 		if (view && !isRtcp(view))
 		{
 			throw new TypeError('not a RTCP packet');
+		}
+
+		// RTCP packet byte length must be multiple of 4.
+		if (view && view.byteLength % 4 !== 0)
+		{
+			throw new RangeError(
+				`RTCP packet byte length must be multiple of 4 but given buffer view is ${view.byteLength} bytes`
+			);
 		}
 
 		this.#packetType = packetType;

--- a/src/rtcp/SenderReportPacket.ts
+++ b/src/rtcp/SenderReportPacket.ts
@@ -239,6 +239,14 @@ export class SenderReportPacket extends RtcpPacket
 			);
 		}
 
+		// Assert that RTCP header length field is correct.
+		if (getRtcpLength(packetView) !== packetView.byteLength)
+		{
+			throw new RangeError(
+				`length in the RTCP header (${getRtcpLength(packetView)} bytes) does not match the available buffer size (${packetView.byteLength} bytes)`
+			);
+		}
+
 		// Update DataView.
 		this.packetView = packetView;
 
@@ -368,6 +376,22 @@ export class SenderReportPacket extends RtcpPacket
 	setReports(reports: ReceiverReport[]): void
 	{
 		this.#reports = Array.from(reports);
+
+		// Update RTCP count.
+		this.setCount(this.#reports.length);
+
+		this.setSerializationNeeded(true);
+	}
+
+	/**
+	 * Add Receiver Report.
+	 *
+	 * @remarks
+	 * - Serialization is needed after calling this method.
+	 */
+	addReport(report: ReceiverReport): void
+	{
+		this.#reports.push(report);
 
 		// Update RTCP count.
 		this.setCount(this.#reports.length);

--- a/src/rtcp/UnknownPacket.ts
+++ b/src/rtcp/UnknownPacket.ts
@@ -1,0 +1,242 @@
+import { RTP_VERSION } from '../Packet';
+import {
+	RtcpPacket,
+	RtcpPacketType,
+	RtcpPacketDump,
+	getRtcpPacketType,
+	getRtcpLength,
+	COMMON_HEADER_LENGTH
+} from './RtcpPacket';
+
+/**
+ *         0                   1                   2                   3
+ *         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * header |V=2|P|    SC   |   PT=???      |             length            |
+ *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * body   |                              ...                              |
+ *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *        :                              ...                              :
+ *        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+
+/**
+ * RTCP Unknown packet info dump.
+ */
+export type UnknownPacketDump = RtcpPacketDump &
+{
+	bodyLength: number;
+};
+
+/**
+ * RTCP Unknown packet.
+ */
+export class UnknownPacket extends RtcpPacket
+{
+	// Buffer view holding the packet body.
+	#bodyView: DataView;
+
+	/**
+	 * @param view - If given it will be parsed. Otherwise an empty RTCP Unknown
+	 *   packet (with just the minimal common header) will be created.
+	 *
+	 * @throws
+	 * - If given `view` does not contain a valid RTCP Unknown packet.
+	 */
+	constructor(view?: DataView, packetType?: RtcpPacketType | number)
+	{
+		super(view ? getRtcpPacketType(view) : packetType!);
+
+		if (!view && !packetType)
+		{
+			throw new TypeError('view or packetType must be given');
+		}
+
+		if (!view)
+		{
+			this.packetView = new DataView(new ArrayBuffer(COMMON_HEADER_LENGTH));
+
+			// Write version and packet type.
+			this.writeCommonHeader();
+
+			// Set empty body.
+			this.#bodyView = new DataView(
+				this.packetView.buffer,
+				this.packetView.byteOffset + COMMON_HEADER_LENGTH,
+				0
+			);
+
+			return;
+		}
+
+		if (getRtcpLength(view) !== view.byteLength)
+		{
+			throw new RangeError(
+				`length in the RTCP header (${getRtcpLength(view)} bytes) does not match view length (${view.byteLength} bytes)`
+			);
+		}
+
+		this.packetView = view;
+
+		// Position relative to the DataView byte offset.
+		let pos = 0;
+
+		// Move to body.
+		pos += COMMON_HEADER_LENGTH;
+
+		// Get padding.
+		if (this.getPaddingBit())
+		{
+			this.padding = this.packetView.getUint8(this.packetView.byteLength - 1);
+		}
+
+		// Get body.
+		const bodyLength = this.packetView.byteLength - pos - this.padding;
+
+		if (bodyLength < 0)
+		{
+			throw new RangeError(
+				`announced padding (${this.padding} bytes) is bigger than available space for body (${this.packetView.byteLength - pos} bytes)`
+			);
+		}
+
+		this.#bodyView = new DataView(
+			this.packetView.buffer,
+			this.packetView.byteOffset + pos,
+			bodyLength
+		);
+
+		pos += (bodyLength + this.padding);
+
+		// Ensure that view length and parsed length match.
+		if (pos !== this.packetView.byteLength)
+		{
+			throw new RangeError(
+				`parsed length (${pos} bytes) does not match view length (${this.packetView.byteLength} bytes)`
+			);
+		}
+	}
+
+	/**
+	 * Dump RTCP Unknown packet info.
+	 */
+	dump(): UnknownPacketDump
+	{
+		return {
+			...super.dump(),
+			bodyLength : this.#bodyView.byteLength
+		};
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	getByteLength(): number
+	{
+		const packetLength =
+			COMMON_HEADER_LENGTH +
+			this.#bodyView.byteLength +
+			this.padding;
+
+		return packetLength;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	serialize(): void
+	{
+		const packetView = super.serializeBase();
+		const packetUint8Array = new Uint8Array(
+			packetView.buffer,
+			packetView.byteOffset,
+			packetView.byteLength
+		);
+
+		// Position relative to the DataView byte offset.
+		let pos = 0;
+
+		// Move to body.
+		pos += COMMON_HEADER_LENGTH;
+
+		// Copy the body into the new buffer.
+		packetUint8Array.set(
+			new Uint8Array(
+				this.#bodyView.buffer,
+				this.#bodyView.byteOffset,
+				this.#bodyView.byteLength
+			),
+			pos
+		);
+
+		pos += this.#bodyView.byteLength;
+
+		pos += this.padding;
+
+		// Assert that current position is equal than new buffer length.
+		if (pos !== packetView.byteLength)
+		{
+			throw new RangeError(
+				`computed packet length (${pos} bytes) is different than the available buffer size (${packetView.byteLength} bytes)`
+			);
+		}
+
+		// Assert that RTCP header length field is correct.
+		if (getRtcpLength(packetView) !== packetView.byteLength)
+		{
+			throw new RangeError(
+				`length in the RTCP header (${getRtcpLength(packetView)} bytes) does not match the available buffer size (${packetView.byteLength} bytes)`
+			);
+		}
+
+		// Update DataView.
+		this.packetView = packetView;
+
+		this.setSerializationNeeded(false);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	clone(buffer?: ArrayBuffer, byteOffset?: number): UnknownPacket
+	{
+		const destPacketView = this.cloneInternal(buffer, byteOffset);
+
+		return new UnknownPacket(destPacketView);
+	}
+
+	/**
+	 * Set the RTCP header count value.
+	 */
+	setCount(count: number): void
+	{
+		this.packetView.setUint8(
+			0,
+			(RTP_VERSION << 6) | (Number(this.getPaddingBit()) << 5) | (count & 0x1F)
+		);
+	}
+
+	/**
+	 * Get the packet body.
+	 */
+	getBody(): DataView
+	{
+		return this.#bodyView;
+	}
+
+	/**
+	 * Set the packet body.
+	 *
+	 * @remarks
+	 * - Serialization is needed after calling this method.
+	 */
+	setBody(view: DataView): void
+	{
+		this.#bodyView = view;
+
+		// Ensure body is padded to 4 bytes.
+		this.padTo4Bytes();
+
+		this.setSerializationNeeded(true);
+	}
+}

--- a/src/tests/RtpPacket.test.ts
+++ b/src/tests/RtpPacket.test.ts
@@ -339,10 +339,6 @@ describe('create RTP packet 6 from scratch', () =>
 		packet.setPayload(stringToDataView('codec'));
 		expect(packet.needsSerialization()).toBe(true);
 		expect(packet.getPayload()).toEqual(stringToDataView('codec'));
-
-		packet.setPadding(3);
-		expect(packet.needsSerialization()).toBe(true);
-		expect(packet.getPadding()).toBe(3);
 	});
 
 	test('packet.clone() succeeds', () =>
@@ -366,7 +362,7 @@ describe('create RTP packet 6 from scratch', () =>
 		expect(clonedPacket.getExtension(2))
 			.toEqual(numericArrayToDataView([ 1, 2, 3, 4 ]));
 		expect(clonedPacket.getPayload()).toEqual(stringToDataView('codec'));
-		expect(clonedPacket.getPadding()).toBe(3);
+		expect(clonedPacket.getPadding()).toBe(0);
 		expect(clonedPacket.dump()).toEqual(packet.dump());
 		expect(clonedPacket.needsSerialization()).toBe(false);
 		// Packet views and payload views must be the same.
@@ -405,13 +401,6 @@ describe('create RTP packet 6 from scratch', () =>
 		// Serialize to reset serialization needed.
 		packet.serialize();
 		expect(packet.needsSerialization()).toBe(false);
-
-		// Remove padding so we can later compare buffers.
-		packet.setPadding(0);
-		expect(packet.needsSerialization()).toBe(true);
-
-		// Serialize to reset serialization needed.
-		packet.serialize();
 
 		const payloadType = packet.getPayloadType();
 		const ssrc = packet.getSsrc();
@@ -600,13 +589,9 @@ describe('create RTP packet 10 from scratch', () =>
 		expect(packet.getByteLength()).toBe(16);
 		expect(packet.getPadding()).toBe(0);
 
-		packet.setPadding(1);
-		expect(packet.needsSerialization()).toBe(true);
-		expect(packet.getByteLength()).toBe(17);
-
-		// Padding a packet of 17 bytes (1 byte of padding) must become 16 bytes.
+		// Padding a packet of 16 bytes (0 byte of padding) must become 16 bytes.
 		packet.padTo4Bytes();
-		expect(packet.needsSerialization()).toBe(true);
+		expect(packet.needsSerialization()).toBe(false);
 		expect(packet.getView().byteLength).toBe(16);
 		expect(packet.getByteLength()).toBe(16);
 		expect(packet.getPadding()).toBe(0);

--- a/src/tests/RtpPacket.test.ts
+++ b/src/tests/RtpPacket.test.ts
@@ -77,7 +77,7 @@ describe('parse RTP packet 2', () =>
 		expect(packet.hasTwoBytesExtensions()).toBe(false);
 		expect(packet.getExtension(3))
 			.toEqual(numericArrayToDataView([ 0x65, 0x34, 0x1E ]));
-		expect(packet.getPayloadView().byteLength).toBe(78);
+		expect(packet.getPayload().byteLength).toBe(78);
 		expect(packet.needsSerialization()).toBe(false);
 	});
 });
@@ -123,7 +123,7 @@ describe('parse RTP packet 3', () =>
 		expect(packet.getPadding()).toBe(0);
 		expect(packet.hasOneByteExtensions()).toBe(true);
 		expect(packet.hasTwoBytesExtensions()).toBe(false);
-		expect(packet.getPayloadView().byteLength).toBe(0);
+		expect(packet.getPayload().byteLength).toBe(0);
 		expect(packet.needsSerialization()).toBe(false);
 	});
 });
@@ -180,7 +180,7 @@ describe('parse RTP packet 4', () =>
 		expect(packet.getExtension(3)).toEqual(numericArrayToDataView([ 0x11, 0x22 ]));
 		expect(packet.getExtension(4)).toEqual(new DataView(new ArrayBuffer(0)));
 		expect(packet.getExtension(5)).toBeUndefined();
-		expect(packet.getPayloadView().byteLength).toBe(0);
+		expect(packet.getPayload().byteLength).toBe(0);
 		expect(packet.needsSerialization()).toBe(false);
 
 		packet.deleteExtension(2);
@@ -221,7 +221,7 @@ describe('parse RTP packet 5 with uncommon header extension value', () =>
 		packet = new RtpPacket(view);
 
 		const packetView = clone<DataView>(packet.getView());
-		const payloadView = clone<DataView>(packet.getPayloadView());
+		const payloadView = clone<DataView>(packet.getPayload());
 		const packetDump = clone<RtpPacketDump>(packet.dump());
 
 		expect(packet.getByteLength()).toBe(array.byteLength);
@@ -235,7 +235,7 @@ describe('parse RTP packet 5 with uncommon header extension value', () =>
 		expect(packet.hasOneByteExtensions()).toBe(false);
 		expect(packet.hasTwoBytesExtensions()).toBe(false);
 		expect(packet.getExtensions().size).toBe(0);
-		expect(packet.getPayloadView().byteLength).toBe(4);
+		expect(packet.getPayload().byteLength).toBe(4);
 		expect(packet.needsSerialization()).toBe(false);
 
 		// Serialize and then compare DataViews.
@@ -244,7 +244,7 @@ describe('parse RTP packet 5 with uncommon header extension value', () =>
 		packet.serialize();
 
 		expect(areDataViewsEqual(packet.getView(), packetView)).toBe(true);
-		expect(areDataViewsEqual(packet.getPayloadView(), payloadView)).toBe(true);
+		expect(areDataViewsEqual(packet.getPayload(), payloadView)).toBe(true);
 		expect(packet.dump()).toEqual(packetDump);
 	});
 });
@@ -264,7 +264,7 @@ describe('create RTP packet 6 from scratch', () =>
 		expect(packet.getSsrc()).toBe(0);
 		expect(packet.getCsrcs()).toEqual([]);
 		expect(packet.getMarker()).toBe(false);
-		expect(packet.getPayloadView()).toEqual(new DataView(new ArrayBuffer(0)));
+		expect(packet.getPayload()).toEqual(new DataView(new ArrayBuffer(0)));
 		expect(packet.getPadding()).toBe(0);
 		expect(packet.hasOneByteExtensions()).toBe(false);
 		expect(packet.hasTwoBytesExtensions()).toBe(false);
@@ -336,9 +336,9 @@ describe('create RTP packet 6 from scratch', () =>
 		expect(packet.getExtensions().size).toBe(1);
 		expect(packet.getExtension(2)).toEqual(numericArrayToDataView([ 1, 2, 3, 4 ]));
 
-		packet.setPayloadView(stringToDataView('codec'));
+		packet.setPayload(stringToDataView('codec'));
 		expect(packet.needsSerialization()).toBe(true);
-		expect(packet.getPayloadView()).toEqual(stringToDataView('codec'));
+		expect(packet.getPayload()).toEqual(stringToDataView('codec'));
 
 		packet.setPadding(3);
 		expect(packet.needsSerialization()).toBe(true);
@@ -365,7 +365,7 @@ describe('create RTP packet 6 from scratch', () =>
 		expect(clonedPacket.hasTwoBytesExtensions()).toBe(true);
 		expect(clonedPacket.getExtension(2))
 			.toEqual(numericArrayToDataView([ 1, 2, 3, 4 ]));
-		expect(clonedPacket.getPayloadView()).toEqual(stringToDataView('codec'));
+		expect(clonedPacket.getPayload()).toEqual(stringToDataView('codec'));
 		expect(clonedPacket.getPadding()).toBe(3);
 		expect(clonedPacket.dump()).toEqual(packet.dump());
 		expect(clonedPacket.needsSerialization()).toBe(false);
@@ -374,15 +374,15 @@ describe('create RTP packet 6 from scratch', () =>
 			clonedPacket.getView(), packet.getView())
 		).toBe(true);
 		expect(areDataViewsEqual(
-			clonedPacket.getPayloadView(), packet.getPayloadView())
+			clonedPacket.getPayload(), packet.getPayload())
 		).toBe(true);
 		// DataViews instances must be different since it's a cloned packet.
 		expect(clonedPacket.getView() === packet.getView()).toBe(false);
-		expect(clonedPacket.getPayloadView() === packet.getPayloadView()).toBe(false);
+		expect(clonedPacket.getPayload() === packet.getPayload()).toBe(false);
 		// Internal ArrayBuffer instances must be different.
 		expect(clonedPacket.getView().buffer === packet.getView().buffer).toBe(false);
 		expect(
-			clonedPacket.getPayloadView().buffer === packet.getPayloadView().buffer
+			clonedPacket.getPayload().buffer === packet.getPayload().buffer
 		).toBe(false);
 
 		// Clone again, now in a given buffer.
@@ -392,11 +392,11 @@ describe('create RTP packet 6 from scratch', () =>
 
 		// DataViews instances must be different since it's a cloned packet.
 		expect(clonedPacket2.getView() === packet.getView()).toBe(false);
-		expect(clonedPacket2.getPayloadView() === packet.getPayloadView()).toBe(false);
+		expect(clonedPacket2.getPayload() === packet.getPayload()).toBe(false);
 		// Internal ArrayBuffer instances must be different.
 		expect(clonedPacket2.getView().buffer === packet.getView().buffer).toBe(false);
 		expect(
-			clonedPacket2.getPayloadView().buffer === packet.getPayloadView().buffer
+			clonedPacket2.getPayload().buffer === packet.getPayload().buffer
 		).toBe(false);
 	});
 
@@ -416,9 +416,9 @@ describe('create RTP packet 6 from scratch', () =>
 		const payloadType = packet.getPayloadType();
 		const ssrc = packet.getSsrc();
 		const sequenceNumber = packet.getSequenceNumber();
-		const payloadLength = packet.getPayloadView().byteLength;
+		const payloadLength = packet.getPayload().byteLength;
 		const packetView = clone<DataView>(packet.getView());
-		const payloadView = clone<DataView>(packet.getPayloadView());
+		const payloadView = clone<DataView>(packet.getPayload());
 		const packetDump = clone<RtpPacketDump>(packet.dump());
 
 		packet.rtxEncode(69, 69696969, 6969);
@@ -427,7 +427,7 @@ describe('create RTP packet 6 from scratch', () =>
 		// Serialize to reset serialization needed.
 		packet.serialize();
 
-		const rtxPayloadView = packet.getPayloadView();
+		const rtxPayloadView = packet.getPayload();
 
 		expect(packet.getPayloadType()).toBe(69);
 		expect(packet.getSequenceNumber()).toBe(6969);
@@ -436,9 +436,9 @@ describe('create RTP packet 6 from scratch', () =>
 		expect(rtxPayloadView.getUint16(0)).toBe(sequenceNumber);
 
 		const payloadWithoutSeqNumberView = new DataView(
-			packet.getPayloadView().buffer,
-			packet.getPayloadView().byteOffset + 2,
-			packet.getPayloadView().byteLength - 2
+			packet.getPayload().buffer,
+			packet.getPayload().byteOffset + 2,
+			packet.getPayload().byteLength - 2
 		);
 
 		expect(areDataViewsEqual(payloadWithoutSeqNumberView, payloadView)).toBe(true);
@@ -449,11 +449,11 @@ describe('create RTP packet 6 from scratch', () =>
 		expect(packet.getPayloadType()).toBe(payloadType);
 		expect(packet.getSequenceNumber()).toBe(sequenceNumber);
 		expect(packet.getSsrc()).toBe(ssrc);
-		expect(packet.getPayloadView().byteLength).toBe(payloadLength);
+		expect(packet.getPayload().byteLength).toBe(payloadLength);
 		expect(packet.needsSerialization()).toBe(true);
 		// Packet and payload views must be the same.
 		expect(areDataViewsEqual(packet.getView(), packetView)).toBe(true);
-		expect(areDataViewsEqual(packet.getPayloadView(), payloadView)).toBe(true);
+		expect(areDataViewsEqual(packet.getPayload(), payloadView)).toBe(true);
 		expect(packet.dump()).toEqual(packetDump);
 	});
 });
@@ -586,7 +586,7 @@ describe('create RTP packet 10 from scratch', () =>
 	{
 		packet = new RtpPacket();
 
-		packet.setPayloadView(numericArrayToDataView([ 1, 2, 3, 4 ]));
+		packet.setPayload(numericArrayToDataView([ 1, 2, 3, 4 ]));
 		expect(packet.needsSerialization()).toBe(true);
 		// Packet total length must match RTP fixed header length (12) + payload
 		// (4), so 16.
@@ -611,7 +611,7 @@ describe('create RTP packet 10 from scratch', () =>
 		expect(packet.getByteLength()).toBe(16);
 		expect(packet.getPadding()).toBe(0);
 
-		packet.setPayloadView(numericArrayToDataView([ 1, 2, 3, 4, 5 ]));
+		packet.setPayload(numericArrayToDataView([ 1, 2, 3, 4, 5 ]));
 		expect(packet.getByteLength()).toBe(17);
 
 		// Padding a packet of 17 bytes (0 bytes of padding) must become 20 bytes.
@@ -627,11 +627,11 @@ describe('serialize packet into a given buffer', () =>
 {
 	const packet = new RtpPacket();
 
-	packet.setPayloadView(numericArrayToDataView([ 1, 2, 3, 4 ]));
+	packet.setPayload(numericArrayToDataView([ 1, 2, 3, 4 ]));
 	packet.serialize();
 
 	const packetView = clone<DataView>(packet.getView());
-	const payloadView = clone<DataView>(packet.getPayloadView());
+	const payloadView = clone<DataView>(packet.getPayload());
 	const packetDump = clone<RtpPacketDump>(packet.dump());
 
 	test('serialization succeeds', () =>
@@ -648,7 +648,7 @@ describe('serialize packet into a given buffer', () =>
 
 		// Packet and payload views must be the same.
 		expect(areDataViewsEqual(packet.getView(), packetView)).toBe(true);
-		expect(areDataViewsEqual(packet.getPayloadView(), payloadView)).toBe(true);
+		expect(areDataViewsEqual(packet.getPayload(), payloadView)).toBe(true);
 		expect(packet.getView().buffer === buffer).toBe(true);
 		expect(packet.getView().byteOffset).toBe(byteOffset);
 		expect(packet.dump()).toEqual(packetDump);

--- a/src/tests/rtcp/ByePacket.test.ts
+++ b/src/tests/rtcp/ByePacket.test.ts
@@ -132,19 +132,13 @@ describe('create RTCP Bye packet', () =>
 		// Byte length must be 4 + 8 (2 ssrcs) = 12.
 		expect(packet.getByteLength()).toBe(12);
 
-		packet.setPadding(9);
-		expect(packet.getPadding()).toBe(9);
-		// Byte length must be 4 + 8 + 9 (padding) = 21.
-		expect(packet.getByteLength()).toBe(21);
-
 		packet.setReason(reason);
-		expect(packet.getPadding()).toBe(9);
-		// Byte length must be 4 + 8 + 24 (reason + reason padding) + 9 (padding) = 45.
-		expect(packet.getByteLength()).toBe(45);
+		// Byte length must be 4 + 8 + 24 (reason + reason padding) = 36.
+		expect(packet.getByteLength()).toBe(36);
 
 		packet.padTo4Bytes();
-		// After padding to 4 bytes, padding must be 0 since the rest of the packet
-		// always fits into groups of 4 bytes.
+		// After padding to 4 bytes, nothing should change since the rest of the
+		// packet always fits into groups of 4 bytes.
 		expect(packet.getPadding()).toBe(0);
 		// Byte length must be 4 + 8 + 24 (reason + reason padding) + 0 (padding) = 36.
 		expect(packet.getByteLength()).toBe(36);

--- a/src/tests/rtcp/CompoundPacket.test.ts
+++ b/src/tests/rtcp/CompoundPacket.test.ts
@@ -3,8 +3,8 @@ import { isRtcp, RtcpPacketType } from '../../rtcp/RtcpPacket';
 import { ReceiverReportPacket } from '../../rtcp/ReceiverReportPacket';
 import { SenderReportPacket } from '../../rtcp/SenderReportPacket';
 import { ByePacket } from '../../rtcp/ByePacket';
-
-import { areDataViewsEqual } from '../../utils';
+import { UnknownPacket } from '../../rtcp/UnknownPacket';
+import { areDataViewsEqual, numericArrayToDataView } from '../../utils';
 
 describe('parse RTCP Compound packet', () =>
 {
@@ -50,7 +50,12 @@ describe('parse RTCP Compound packet', () =>
 			0x74, 0x61, 0x20, 0x6c,
 			0x61, 0x20, 0x76, 0x69,
 			0x73, 0x74, 0x61, 0x00,
-			0x00, 0x00, 0x00, 0x04 // Padding (4 bytes)
+			0x00, 0x00, 0x00, 0x04, // Padding (4 bytes)
+			/* Unknown packet */
+			0xa2, 0xc1, 0x00, 0x03, // Padding, Type: 193 (unknown), Count: 2, length: 3
+			0x11, 0x22, 0x33, 0x44, // Body
+			0x55, 0x66, 0x77, 0x88,
+			0x99, 0x00, 0x00, 0x03 // Padding (3 bytes)
 		]
 	);
 
@@ -65,13 +70,13 @@ describe('parse RTCP Compound packet', () =>
 		expect(isRtcp(view)).toBe(true);
 	});
 
-	test('packet processing succeeds', () =>
+	test.only('packet processing succeeds', () =>
 	{
 		const compoundPacket = new CompoundPacket(view);
 
 		expect(compoundPacket.needsSerialization()).toBe(false);
-		expect(compoundPacket.getByteLength()).toBe(140);
-		expect(compoundPacket.getPackets().length).toBe(3);
+		expect(compoundPacket.getByteLength()).toBe(156);
+		expect(compoundPacket.getPackets().length).toBe(4);
 		expect(areDataViewsEqual(compoundPacket.getView(), view)).toBe(true);
 
 		const packet1 = compoundPacket.getPackets()[0] as ReceiverReportPacket;
@@ -107,19 +112,37 @@ describe('parse RTCP Compound packet', () =>
 		expect(packet3.getSsrcs()).toEqual([ 0x624276e0, 0x2624670e ]);
 		expect(packet3.getReason()).toBe('Hasta la vista');
 
+		const packet4 = compoundPacket.getPackets()[3] as UnknownPacket;
+
+		expect(packet4.needsSerialization()).toBe(false);
+		expect(packet4.getByteLength()).toBe(16);
+		expect(packet4.getPacketType()).toBe(193);
+		expect(packet4.getCount()).toBe(2);
+		expect(packet4.getPadding()).toBe(3);
+		expect(packet4.needsSerialization()).toBe(false);
+		expect(packet4.getBody()).toEqual(numericArrayToDataView(
+			[ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 ]
+		));
+
 		expect(compoundPacket.dump()).toEqual(
 			{
 				padding    : 0,
-				byteLength : 140,
-				packets    : [ packet1.dump(), packet2.dump(), packet3.dump() ]
+				byteLength : 156,
+				packets    :
+				[
+					packet1.dump(),
+					packet2.dump(),
+					packet3.dump(),
+					packet4.dump()
+				]
 			});
 
 		// Also test the same after serializing.
 		compoundPacket.serialize();
 
 		expect(compoundPacket.needsSerialization()).toBe(false);
-		expect(compoundPacket.getByteLength()).toBe(140);
-		expect(compoundPacket.getPackets().length).toBe(3);
+		expect(compoundPacket.getByteLength()).toBe(156);
+		expect(compoundPacket.getPackets().length).toBe(4);
 		expect(areDataViewsEqual(compoundPacket.getView(), view)).toBe(true);
 
 		const packet1B = compoundPacket.getPackets()[0] as ReceiverReportPacket;
@@ -155,11 +178,29 @@ describe('parse RTCP Compound packet', () =>
 		expect(packet3B.getSsrcs()).toEqual([ 0x624276e0, 0x2624670e ]);
 		expect(packet3B.getReason()).toBe('Hasta la vista');
 
+		const packet4B = compoundPacket.getPackets()[3] as UnknownPacket;
+
+		expect(packet4B.needsSerialization()).toBe(false);
+		expect(packet4B.getByteLength()).toBe(16);
+		expect(packet4B.getPacketType()).toBe(193);
+		expect(packet4B.getCount()).toBe(2);
+		expect(packet4B.getPadding()).toBe(3);
+		expect(packet4B.needsSerialization()).toBe(false);
+		expect(packet4B.getBody()).toEqual(numericArrayToDataView(
+			[ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 ]
+		));
+
 		expect(compoundPacket.dump()).toEqual(
 			{
 				padding    : 0,
-				byteLength : 140,
-				packets    : [ packet1B.dump(), packet2B.dump(), packet3B.dump() ]
+				byteLength : 156,
+				packets    :
+				[
+					packet1B.dump(),
+					packet2B.dump(),
+					packet3B.dump(),
+					packet4B.dump()
+				]
 			});
 	});
 

--- a/src/tests/rtcp/ReceiverReportPacket.test.ts
+++ b/src/tests/rtcp/ReceiverReportPacket.test.ts
@@ -171,24 +171,19 @@ describe('create RTCP Receiver Report packet', () =>
 		packet.setSsrc(1111);
 		expect(packet.getSsrc()).toBe(1111);
 
-		packet.setPadding(3);
-		expect(packet.getPadding()).toBe(3);
-		// Byte length must be 8 + 3 (padding) = 11.
-		expect(packet.getByteLength()).toBe(11);
-
 		packet.padTo4Bytes();
-		// After padding to 4 bytes, padding must be 0 since the rest of the packet
-		// always fits into groups of 4 bytes.
+		// After padding to 4 bytes, nothing should change since the rest of the
+		// packet always fits into groups of 4 bytes.
 		expect(packet.getPadding()).toBe(0);
 		// Byte length must be 8.
 		expect(packet.getByteLength()).toBe(8);
 
-		expect(packet.needsSerialization()).toBe(true);
+		expect(packet.needsSerialization()).toBe(false);
 		expect(packet.getPacketType()).toBe(RtcpPacketType.RR);
 		expect(packet.getCount()).toBe(0);
 		expect(packet.getPadding()).toBe(0);
 		expect(packet.getSsrc()).toBe(1111);
-		expect(packet.needsSerialization()).toBe(true);
+		expect(packet.needsSerialization()).toBe(false);
 
 		packet.serialize();
 

--- a/src/tests/rtcp/SenderReportPacket.test.ts
+++ b/src/tests/rtcp/SenderReportPacket.test.ts
@@ -189,19 +189,14 @@ describe('create RTCP Sender Report packet', () =>
 		expect(packet.getPacketCount()).toBe(666);
 		expect(packet.getOctetCount()).toBe(999);
 
-		packet.setPadding(3);
-		expect(packet.getPadding()).toBe(3);
-		// Byte length must be 28 + 3 (padding) = 31.
-		expect(packet.getByteLength()).toBe(31);
-
 		packet.padTo4Bytes();
-		// After padding to 4 bytes, padding must be 0 since the rest of the packet
-		// always fits into groups of 4 bytes.
+		// After padding to 4 bytes, nothing should change since the rest of the
+		// packet always fits into groups of 4 bytes.
 		expect(packet.getPadding()).toBe(0);
 		// Byte length must be 28.
 		expect(packet.getByteLength()).toBe(28);
 
-		expect(packet.needsSerialization()).toBe(true);
+		expect(packet.needsSerialization()).toBe(false);
 		expect(packet.getPacketType()).toBe(RtcpPacketType.SR);
 		expect(packet.getCount()).toBe(0);
 		expect(packet.getPadding()).toBe(0);
@@ -211,7 +206,7 @@ describe('create RTCP Sender Report packet', () =>
 		expect(packet.getRtpTimestamp()).toBe(123456789);
 		expect(packet.getPacketCount()).toBe(666);
 		expect(packet.getOctetCount()).toBe(999);
-		expect(packet.needsSerialization()).toBe(true);
+		expect(packet.needsSerialization()).toBe(false);
 
 		packet.serialize();
 

--- a/src/tests/rtcp/UnknownPacket.test.ts
+++ b/src/tests/rtcp/UnknownPacket.test.ts
@@ -126,15 +126,11 @@ describe('create RTCP unknown packet', () =>
 		packet.setCount(5);
 		expect(packet.getCount()).toBe(5);
 
-		packet.setPadding(2);
-		expect(packet.getPadding()).toBe(2);
-		// Byte length must be 4 + 3 + 2 (padding) = 9.
-		expect(packet.getByteLength()).toBe(9);
-
 		packet.padTo4Bytes();
-		// After padding to 4 bytes, padding must be 1.
+		// After padding to 4 bytes, nothing should change since the rest of the
+		// packet always fits into groups of 4 bytes.
 		expect(packet.getPadding()).toBe(1);
-		// Byte length must be 4 + 3 + 1 = 8.
+		// Byte length must be 4 + 3 (body) + 1 (padding) = 8.
 		expect(packet.getByteLength()).toBe(8);
 
 		expect(packet.needsSerialization()).toBe(true);

--- a/src/tests/rtcp/UnknownPacket.test.ts
+++ b/src/tests/rtcp/UnknownPacket.test.ts
@@ -1,0 +1,187 @@
+import { UnknownPacket } from '../../rtcp/UnknownPacket';
+import { isRtcp } from '../../rtcp/RtcpPacket';
+import { areDataViewsEqual, numericArrayToDataView } from '../../utils';
+
+describe('parse RTCP unknown packet', () =>
+{
+	const array = new Uint8Array(
+		[
+			0x82, 0xc0, 0x00, 0x02, // Type: 192 (unknown), Count: 2, length: 2
+			0x62, 0x42, 0x76, 0xe0, // Body
+			0x26, 0x24, 0x67, 0x0e
+		]
+	);
+
+	const view = new DataView(
+		array.buffer,
+		array.byteOffset,
+		array.byteLength
+	);
+
+	test('buffer view is RTCP', () =>
+	{
+		expect(isRtcp(view)).toBe(true);
+	});
+
+	test('packet processing succeeds', () =>
+	{
+		const packet = new UnknownPacket(view);
+
+		expect(packet.needsSerialization()).toBe(false);
+		expect(packet.getByteLength()).toBe(12);
+		expect(packet.getPacketType()).toBe(192);
+		expect(packet.getCount()).toBe(2);
+		expect(packet.getPadding()).toBe(0);
+		expect(packet.getBody()).toEqual(numericArrayToDataView(
+			[ 0x62, 0x42, 0x76, 0xe0, 0x26, 0x24, 0x67, 0x0e ]
+		));
+		expect(packet.needsSerialization()).toBe(false);
+	});
+
+	test('packet processing succeeds for a buffer view with padding', () =>
+	{
+		const array2 = new Uint8Array(
+			[
+				0xa2, 0xc1, 0x00, 0x03, // Padding, Type: 193 (unknown), Count: 2, length: 3
+				0x11, 0x22, 0x33, 0x44, // Body
+				0x55, 0x66, 0x77, 0x88,
+				0x99, 0x00, 0x00, 0x03 // Padding (3 bytes)
+			]
+		);
+
+		const view2 = new DataView(
+			array2.buffer,
+			array2.byteOffset,
+			array2.byteLength
+		);
+
+		const packet = new UnknownPacket(view2);
+
+		expect(packet.needsSerialization()).toBe(false);
+		expect(packet.getByteLength()).toBe(16);
+		expect(packet.getPacketType()).toBe(193);
+		expect(packet.getCount()).toBe(2);
+		expect(packet.getPadding()).toBe(3);
+		expect(packet.needsSerialization()).toBe(false);
+		expect(packet.getBody()).toEqual(numericArrayToDataView(
+			[ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 ]
+		));
+		expect(areDataViewsEqual(packet.getView(), view2)).toBe(true);
+
+		// Also test the same after serializing.
+		packet.serialize();
+
+		expect(packet.needsSerialization()).toBe(false);
+		expect(packet.getByteLength()).toBe(16);
+		expect(packet.getPacketType()).toBe(193);
+		expect(packet.getCount()).toBe(2);
+		expect(packet.getPadding()).toBe(3);
+		expect(packet.needsSerialization()).toBe(false);
+		expect(packet.getBody()).toEqual(numericArrayToDataView(
+			[ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99 ]
+		));
+		expect(areDataViewsEqual(packet.getView(), view2)).toBe(true);
+	});
+
+	test('parsing a buffer view which length does not fit the indicated count throws', () =>
+	{
+		// Parse the first 8 bytes of the buffer so RTCP length is wrong.
+		const view3 = new DataView(
+			array.buffer,
+			array.byteOffset,
+			8
+		);
+
+		expect(() => (new UnknownPacket(view3)))
+			.toThrowError(RangeError);
+	});
+});
+
+describe('create RTCP unknown packet', () =>
+{
+	test('creating a unknown packet without view and packet type throws', () =>
+	{
+		expect(() => (new UnknownPacket()))
+			.toThrowError(TypeError);
+	});
+
+	test('creating a unknown packet with padding succeeds', () =>
+	{
+		const packet = new UnknownPacket(undefined, 199);
+
+		expect(isRtcp(packet.getView())).toBe(true);
+		expect(packet.needsSerialization()).toBe(false);
+		// Byte length must be 4 (common header).
+		expect(packet.getByteLength()).toBe(4);
+		expect(packet.getPacketType()).toBe(199);
+		expect(packet.getCount()).toBe(0);
+		expect(packet.getPadding()).toBe(0);
+		expect(packet.getBody()).toEqual(numericArrayToDataView([]));
+		expect(packet.needsSerialization()).toBe(false);
+
+		packet.setBody(numericArrayToDataView([ 1, 2, 3 ]));
+		// Byte length must be 4 + 3 (body) + 1 (padding) = 8.
+		expect(packet.getByteLength()).toBe(8);
+
+		packet.setCount(5);
+		expect(packet.getCount()).toBe(5);
+
+		packet.setPadding(2);
+		expect(packet.getPadding()).toBe(2);
+		// Byte length must be 4 + 3 + 2 (padding) = 9.
+		expect(packet.getByteLength()).toBe(9);
+
+		packet.padTo4Bytes();
+		// After padding to 4 bytes, padding must be 1.
+		expect(packet.getPadding()).toBe(1);
+		// Byte length must be 4 + 3 + 1 = 8.
+		expect(packet.getByteLength()).toBe(8);
+
+		expect(packet.needsSerialization()).toBe(true);
+		expect(packet.getPacketType()).toBe(199);
+		expect(packet.getCount()).toBe(5);
+		expect(packet.getPadding()).toBe(1);
+		expect(packet.getBody()).toEqual(numericArrayToDataView([ 1, 2, 3 ]));
+		expect(packet.needsSerialization()).toBe(true);
+
+		packet.serialize();
+
+		expect(packet.needsSerialization()).toBe(false);
+		expect(packet.getPacketType()).toBe(199);
+		expect(packet.getCount()).toBe(5);
+		expect(packet.getPadding()).toBe(1);
+		expect(packet.getBody()).toEqual(numericArrayToDataView([ 1, 2, 3 ]));
+		expect(packet.needsSerialization()).toBe(false);
+		expect(isRtcp(packet.getView())).toBe(true);
+	});
+
+	test('packet.clone() succeeds', () =>
+	{
+		const array = new Uint8Array(
+			[
+				0xa2, 0xc1, 0x00, 0x03, // Padding, Type: 193 (unknown), Count: 2, length: 3
+				0x11, 0x22, 0x33, 0x44, // Body
+				0x55, 0x66, 0x77, 0x88,
+				0x99, 0x00, 0x00, 0x03 // Padding (3 bytes)
+			]
+		);
+
+		const view = new DataView(
+			array.buffer,
+			array.byteOffset,
+			array.byteLength
+		);
+
+		const packet = new UnknownPacket(view);
+		const clonedPacket = packet.clone();
+
+		expect(clonedPacket.needsSerialization()).toBe(false);
+		expect(clonedPacket.getByteLength()).toBe(16);
+		expect(clonedPacket.getPacketType()).toBe(193);
+		expect(clonedPacket.getCount()).toBe(2);
+		expect(clonedPacket.getPadding()).toBe(3);
+		expect(clonedPacket.getBody()).toEqual(packet.getBody());
+		expect(clonedPacket.dump()).toEqual(packet.dump());
+		expect(areDataViewsEqual(clonedPacket.getView(), packet.getView())).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #14

Also remove `setPadding()` method since nobody should use it. Instead ensure that RTCP packets are always multiple of 4 bytes.