### PR TITLE
CI: Remove deprecated ubuntu-20.04 host and add windows-2025

### DIFF
--- a/.github/workflows/rtp.js.yaml
+++ b/.github/workflows/rtp.js.yaml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix:
         ci:
-          - os: ubuntu-20.04
-            node: 18
           - os: ubuntu-22.04
+            node: 18
+          - os: ubuntu-24.04
             node: 20
           - os: ubuntu-24.04
             node: 22
@@ -30,6 +30,8 @@ jobs:
           - os: macos-15
             node: 22
           - os: windows-2022
+            node: 20
+          - os: windows-2025
             node: 22
 
     runs-on: ${{ matrix.ci.os }}


### PR DESCRIPTION
### Details

- https://github.com/actions/runner-images/issues/11101
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners